### PR TITLE
Fix option validation for namespace requirement

### DIFF
--- a/kfk/option_extensions.py
+++ b/kfk/option_extensions.py
@@ -17,8 +17,8 @@ class NotRequiredIf(click.Option):
         control_options_exist = False
 
         for options in self.options:
-            control_options_exist = options in opts
-            if control_options_exist is True:
+            if opts.get(options):
+                control_options_exist = True
                 break
 
         if control_options_exist:
@@ -43,8 +43,8 @@ class RequiredIf(click.Option):
         control_options_exist = False
 
         for options in self.options:
-            control_options_exist = options in opts
-            if control_options_exist is True:
+            if opts.get(options):
+                control_options_exist = True
                 break
 
         if control_options_exist:


### PR DESCRIPTION
## Summary
- Fix `NotRequiredIf` and `RequiredIf` in `option_extensions.py` to check option truthy values instead of just key presence
- For `is_flag` options (like `--list`), the key is always present in opts (True or False), so `options in opts` was always True, making namespace always optional
- This caused `kfk clusters --alter --cluster my-cluster` without `-n` to pass `None` to kubectl, adding `--all-namespaces` to `kubectl edit` which doesn't support it

## Test plan
- [x] Verify `kfk clusters --alter --cluster my-cluster` without `-n` shows a proper Click error for missing namespace
- [x] Verify `kfk clusters --list` without `-n` still works (lists all namespaces)
- [x] Verify `kfk clusters --alter --cluster my-cluster -n kafka` still works normally

Fixes #83
Fixes #94