### PR TITLE
Add --broker-pod option and fix remaining pod naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: ['3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Install setuptools for Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,6 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.8
-    hooks:
-      - id: docformatter
-
-
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: v1.7.8
     hooks:
       - id: docformatter
 

--- a/kfk/commands/acls.py
+++ b/kfk/commands/acls.py
@@ -12,6 +12,7 @@ from kfk.option_extensions import NotRequiredIf
 
 @click.option("-n", "--namespace", help="Namespace to use.", required=True)
 @click.option("-c", "--kafka-cluster", help="Cluster to use.", required=True)
+@click.option("--broker-pod", help="Broker pod name to exec into.")
 @click.option("--remove", help="Indicates you are trying to remove ACLs.", is_flag=True)
 @click.option(
     "--resource-pattern-type",
@@ -84,6 +85,7 @@ def acls(
     deny_host,
     resource_pattern_type,
     remove,
+    broker_pod,
     kafka_cluster,
     namespace,
 ):
@@ -93,9 +95,10 @@ def acls(
             "bin/kafka-acls.sh --bootstrap-server"
             " localhost:9092 --list {topic}{cluster} {group}"
         )
+        pod = broker_pod or "{kafka_cluster}-broker-0"
         os.system(
             Kubectl()
-            .exec("-it", "{kafka_cluster}-broker-0")
+            .exec("-it", pod)
             .container("kafka")
             .namespace(namespace)
             .exec_command(native_command)

--- a/kfk/commands/configs.py
+++ b/kfk/commands/configs.py
@@ -19,6 +19,7 @@ from kfk.option_extensions import NotRequiredIf
 
 @click.option("-n", "--namespace", help="Namespace to use", required=True)
 @click.option("-c", "--cluster", help="Cluster to use", required=True)
+@click.option("--broker-pod", help="Broker pod name to exec into.")
 @click.option("--delete-config", help="Config keys to remove")
 @click.option("--add-config", help="Key Value pairs of configs to add.")
 @click.option("--alter", help="Alter the configuration for the entity.", is_flag=True)
@@ -47,6 +48,7 @@ def configs(
     alter,
     add_config,
     delete_config,
+    broker_pod,
     cluster,
     namespace,
 ):
@@ -54,17 +56,23 @@ def configs(
     if describe:
         if entity_type == "topics":
             if native:
-                _describe_natively(entity_type, entity_name, cluster, namespace)
+                _describe_natively(
+                    entity_type, entity_name, cluster, namespace, broker_pod
+                )
             else:
                 topics.describe(entity_name, None, False, None, cluster, namespace)
         elif entity_type == "users":
             if native:
-                _describe_natively(entity_type, entity_name, cluster, namespace)
+                _describe_natively(
+                    entity_type, entity_name, cluster, namespace, broker_pod
+                )
             else:
                 users.describe(entity_name, None, cluster, namespace)
         elif entity_type == "brokers":
             if native:
-                _describe_natively(entity_type, entity_name, cluster, namespace)
+                _describe_natively(
+                    entity_type, entity_name, cluster, namespace, broker_pod
+                )
                 stream = get_resource_as_stream(
                     "configmap",
                     resource_name=cluster + "-kafka-config",
@@ -124,7 +132,7 @@ def configs(
         raise_exception_for_missing_options("configs")
 
 
-def _describe_natively(entity_type, entity_name, cluster, namespace):
+def _describe_natively(entity_type, entity_name, cluster, namespace, broker_pod=None):
     native_command = (
         "bin/kafka-configs.sh --bootstrap-server {cluster}-kafka-brokers:{port} "
         "--entity-type {entity_type} --describe"
@@ -136,9 +144,10 @@ def _describe_natively(entity_type, entity_name, cluster, namespace):
         if entity_type == "users":
             entity_name = COMMON_NAME_PREFIX + entity_name
 
+    pod = broker_pod or cluster + "-broker-0"
     os.system(
         Kubectl()
-        .exec("-it", cluster + "-kafka-0")
+        .exec("-it", pod)
         .container("kafka")
         .namespace(namespace)
         .exec_command(native_command)

--- a/kfk/commands/console.py
+++ b/kfk/commands/console.py
@@ -14,15 +14,18 @@ from kfk.kubectl_command_builder import Kubectl
 @click.option(
     "--consumer.config", "consumer_config", help="Consumer config properties file."
 )
+@click.option("--broker-pod", help="Broker pod name to exec into.")
 @click.option("--topic", help="Topic Name", required=True)
 @kfk.command()
-def console_consumer(topic, consumer_config, from_beginning, cluster, namespace):
+def console_consumer(
+    topic, broker_pod, consumer_config, from_beginning, cluster, namespace
+):
     """Reads data from Kafka topics and outputs it to standard output."""
     native_command = (
         "bin/kafka-console-consumer.sh --bootstrap-server"
         " {cluster}-kafka-brokers:{port} --topic {topic} {from_beginning}"
     )
-    pod = cluster + "-broker-0"
+    pod = broker_pod or cluster + "-broker-0"
     container = "kafka"
     if consumer_config is not None:
         native_command = apply_client_config_from_file(
@@ -54,15 +57,16 @@ def console_consumer(topic, consumer_config, from_beginning, cluster, namespace)
 @click.option(
     "--producer.config", "producer_config", help="Producer config properties file."
 )
+@click.option("--broker-pod", help="Broker pod name to exec into.")
 @click.option("--topic", help="Topic Name", required=True)
 @kfk.command()
-def console_producer(topic, producer_config, cluster, namespace):
+def console_producer(topic, broker_pod, producer_config, cluster, namespace):
     """Reads data from standard input and publish it to Kafka."""
     native_command = (
         "bin/kafka-console-producer.sh --broker-list {cluster}-kafka-brokers:{port}"
         " --topic {topic}"
     )
-    pod = cluster + "-broker-0"
+    pod = broker_pod or cluster + "-broker-0"
     container = "kafka"
     if producer_config is not None:
         native_command = apply_client_config_from_file(

--- a/kfk/commands/topics.py
+++ b/kfk/commands/topics.py
@@ -26,6 +26,7 @@ from kfk.option_extensions import NotRequiredIf, RequiredIf
 
 @click.option("-n", "--namespace", help="Namespace to use", required=True)
 @click.option("-c", "--cluster", help="Cluster to use", required=True)
+@click.option("--broker-pod", help="Broker pod name to exec into.")
 @click.option(
     "--delete-config",
     help="A topic configuration override to be removed for an existing topic",
@@ -106,6 +107,7 @@ def topics(
     is_alter,
     config,
     delete_config,
+    broker_pod,
     cluster,
     namespace,
 ):
@@ -115,7 +117,7 @@ def topics(
     elif is_create:
         create(topic, partitions, replication_factor, config, cluster, namespace)
     elif is_describe:
-        describe(topic, output, native, command_config, cluster, namespace)
+        describe(topic, output, native, command_config, cluster, namespace, broker_pod)
     elif is_delete:
         delete(topic, cluster, namespace)
     elif is_alter:
@@ -167,7 +169,9 @@ def create(topic, partitions, replication_factor, config, cluster, namespace):
         topic_temp_file.close()
 
 
-def describe(topic, output, native, command_config, cluster, namespace):
+def describe(
+    topic, output, native, command_config, cluster, namespace, broker_pod=None
+):
     if output is not None:
         os.system(
             Kubectl()
@@ -183,7 +187,7 @@ def describe(topic, output, native, command_config, cluster, namespace):
                 "bin/kafka-topics.sh --bootstrap-server {cluster}-kafka-brokers:{port}"
                 " --describe --topic {topic}"
             )
-            pod = cluster + "-kafka-0"
+            pod = broker_pod or cluster + "-broker-0"
             container = "kafka"
             if command_config is not None:
                 native_command = apply_client_config_from_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Command Line Interface for Strimzi Kafka Operator"
 authors = [{ name = "Aykut Bulgu", email = "aykut@systemcraftsman.com" }]
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.11,<3.15"
 keywords = ["kafka", "strimzi", "cli", "operator", "kubernetes", "k8s", "openshift", "apache-kafka"]
 
 classifiers=[
@@ -13,11 +13,10 @@ classifiers=[
     'Topic :: Software Development',
     'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: 3 :: Only',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: POSIX :: Linux',
@@ -92,7 +91,7 @@ imports = ["kfk"]
 
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312", "py313"]
+target-version = ["py311", "py312", "py313"]
 line-length = 88
 include = '\.pyi?$'
 exclude = '''

--- a/tests/test_configs_command.py
+++ b/tests/test_configs_command.py
@@ -210,7 +210,7 @@ class TestKfkConfigs(TestCase):
         )
         mock_os.system.assert_called_with(
             Kubectl()
-            .exec("-it", "{cluster}-kafka-0")
+            .exec("-it", "{cluster}-broker-0")
             .container("kafka")
             .namespace(self.namespace)
             .exec_command(native_command)
@@ -374,7 +374,7 @@ class TestKfkConfigs(TestCase):
         )
         mock_os.system.assert_called_with(
             Kubectl()
-            .exec("-it", "{cluster}-kafka-0")
+            .exec("-it", "{cluster}-broker-0")
             .container("kafka")
             .namespace(self.namespace)
             .exec_command(native_command)
@@ -519,7 +519,7 @@ class TestKfkConfigs(TestCase):
 
             mock_os.system.assert_called_with(
                 Kubectl()
-                .exec("-it", "{cluster}-kafka-0")
+                .exec("-it", "{cluster}-broker-0")
                 .container("kafka")
                 .namespace(self.namespace)
                 .exec_command(native_command)
@@ -568,7 +568,7 @@ class TestKfkConfigs(TestCase):
 
             mock_os.system.assert_called_with(
                 Kubectl()
-                .exec("-it", "{cluster}-kafka-0")
+                .exec("-it", "{cluster}-broker-0")
                 .container("kafka")
                 .namespace(self.namespace)
                 .exec_command(native_command)

--- a/tests/test_topics_command.py
+++ b/tests/test_topics_command.py
@@ -114,7 +114,7 @@ class TestKfkTopics(TestCase):
         )
         mock_os.system.assert_called_with(
             Kubectl()
-            .exec("-it", "{cluster}-kafka-0")
+            .exec("-it", "{cluster}-broker-0")
             .container("kafka")
             .namespace(self.namespace)
             .exec_command(native_command)
@@ -151,7 +151,7 @@ class TestKfkTopics(TestCase):
         )
         mock_os.system.assert_called_with(
             Kubectl()
-            .exec("-it", "{cluster}-kafka-0")
+            .exec("-it", "{cluster}-broker-0")
             .container("kafka")
             .namespace(self.namespace)
             .exec_command(native_command)


### PR DESCRIPTION
## Summary
- Fix remaining `{cluster}-kafka-0` references in `configs.py` and `topics.py` to use `{cluster}-broker-0` (KafkaNodePool-based naming from Strimzi 1.0.0)
- Add `--broker-pod` option to `console-consumer`, `console-producer`, `acls`, `topics`, and `configs` commands, allowing users with custom KafkaNodePool names to override the default broker pod
- Drop Python 3.9 and 3.10 support (both EOL), add Python 3.14 support. New range: `>=3.11,<3.15`
- Remove docformatter from pre-commit hooks (conflicts with black and flake8, not used by Django/pytest/pandas/SQLAlchemy)

Fixes #120

## Test plan
- [x] All 48 affected tests pass (configs, topics, console, acls)
- [x] Pre-commit hooks pass
- [x] CI builds pass for Python 3.11, 3.12, 3.13, 3.14
- [x] Verify `kfk console-consumer --help` shows `--broker-pod` option
- [x] Verify `kfk console-producer --help` shows `--broker-pod` option
- [x] Verify `kfk topics --help` shows `--broker-pod` option
- [x] Verify `kfk configs --help` shows `--broker-pod` option