### PR TITLE
Replace kubectl get/describe with Python K8s client

### DIFF
--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import click
@@ -18,6 +19,9 @@ from kfk.kubectl_command_builder import Kubectl
 from kfk.kubernetes_commons import (
     create_using_yaml,
     delete_using_yaml,
+    describe_resource,
+    get_resource,
+    list_resource,
     replace_using_yaml,
 )
 from kfk.messages import Messages
@@ -109,7 +113,7 @@ def clusters(
 
 
 def list(namespace):
-    os.system(Kubectl().get().kafkas().namespace(namespace).build())
+    list_resource("kafkas", namespace)
 
 
 def create(cluster, replicas, config, namespace, is_yes):
@@ -150,11 +154,13 @@ def create(cluster, replicas, config, namespace, is_yes):
 
 def describe(cluster, output, namespace):
     if output is not None:
-        os.system(
-            Kubectl().get().kafkas(cluster).namespace(namespace).output(output).build()
-        )
+        resource = get_resource("kafkas", cluster, namespace)
+        if output == "yaml":
+            click.echo(yaml.dump(resource, default_flow_style=False))
+        elif output == "json":
+            click.echo(json.dumps(resource, indent=2))
     else:
-        os.system(Kubectl().describe().kafkas(cluster).namespace(namespace).build())
+        describe_resource("kafkas", cluster, namespace)
 
 
 def delete(cluster, namespace, is_yes):

--- a/kfk/commands/connect/clusters.py
+++ b/kfk/commands/connect/clusters.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import click
@@ -31,6 +32,9 @@ from kfk.kubernetes_commons import (
     create_using_yaml,
     delete_object,
     delete_using_yaml,
+    describe_resource,
+    get_resource,
+    list_resource,
     replace_using_yaml,
 )
 from kfk.messages import Errors, Messages
@@ -140,7 +144,7 @@ def clusters(
 
 
 def list(namespace):
-    os.system(Kubectl().get().kafkaconnects().namespace(namespace).build())
+    list_resource("kafkaconnects", namespace)
 
 
 def create(
@@ -261,18 +265,13 @@ def create(
 
 def describe(cluster, output, namespace):
     if output is not None:
-        os.system(
-            Kubectl()
-            .get()
-            .kafkaconnects(cluster)
-            .namespace(namespace)
-            .output(output)
-            .build()
-        )
+        resource = get_resource("kafkaconnects", cluster, namespace)
+        if output == "yaml":
+            click.echo(yaml.dump(resource, default_flow_style=False))
+        elif output == "json":
+            click.echo(json.dumps(resource, indent=2))
     else:
-        os.system(
-            Kubectl().describe().kafkaconnects(cluster).namespace(namespace).build()
-        )
+        describe_resource("kafkaconnects", cluster, namespace)
 
 
 def delete(cluster, namespace, is_yes):

--- a/kfk/commands/connect/connectors.py
+++ b/kfk/commands/connect/connectors.py
@@ -1,4 +1,4 @@
-import os
+import json
 
 import click
 import yaml
@@ -15,10 +15,12 @@ from kfk.commons import (
 )
 from kfk.config import STRIMZI_PATH, STRIMZI_VERSION
 from kfk.constants import SpecialTexts
-from kfk.kubectl_command_builder import Kubectl
 from kfk.kubernetes_commons import (
     create_using_yaml,
     delete_using_yaml,
+    describe_resource,
+    get_resource,
+    list_resource,
     replace_using_yaml,
 )
 
@@ -91,15 +93,7 @@ def connectors(
 
 
 def list(cluster, namespace):
-    os.system(
-        Kubectl()
-        .get()
-        .kafkaconnectors()
-        .label("strimzi.io/cluster={cluster}")
-        .namespace(namespace)
-        .build()
-        .format(cluster=cluster)
-    )
+    list_resource("kafkaconnectors", namespace, label=f"strimzi.io/cluster={cluster}")
 
 
 def create(config_file, cluster, namespace):
@@ -141,18 +135,13 @@ def create(config_file, cluster, namespace):
 
 def describe(connector, output, namespace):
     if output is not None:
-        os.system(
-            Kubectl()
-            .get()
-            .kafkaconnectors(connector)
-            .namespace(namespace)
-            .output(output)
-            .build()
-        )
+        resource = get_resource("kafkaconnectors", connector, namespace)
+        if output == "yaml":
+            click.echo(yaml.dump(resource, default_flow_style=False))
+        elif output == "json":
+            click.echo(json.dumps(resource, indent=2))
     else:
-        os.system(
-            Kubectl().describe().kafkaconnectors(connector).namespace(namespace).build()
-        )
+        describe_resource("kafkaconnectors", connector, namespace)
 
 
 def delete(connector, cluster, namespace):

--- a/kfk/commands/topics.py
+++ b/kfk/commands/topics.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import click
@@ -19,6 +20,9 @@ from kfk.kubectl_command_builder import Kubectl
 from kfk.kubernetes_commons import (
     create_using_yaml,
     delete_using_yaml,
+    describe_resource,
+    get_resource,
+    list_resource,
     replace_using_yaml,
 )
 from kfk.option_extensions import NotRequiredIf, RequiredIf
@@ -135,15 +139,7 @@ def topics(
 
 
 def list(cluster, namespace):
-    os.system(
-        Kubectl()
-        .get()
-        .kafkatopics()
-        .label("strimzi.io/cluster={cluster}")
-        .namespace(namespace)
-        .build()
-        .format(cluster=cluster)
-    )
+    list_resource("kafkatopics", namespace, label=f"strimzi.io/cluster={cluster}")
 
 
 def create(topic, partitions, replication_factor, config, cluster, namespace):
@@ -173,14 +169,11 @@ def describe(
     topic, output, native, command_config, cluster, namespace, broker_pod=None
 ):
     if output is not None:
-        os.system(
-            Kubectl()
-            .get()
-            .kafkatopics(topic)
-            .namespace(namespace)
-            .output(output)
-            .build()
-        )
+        resource = get_resource("kafkatopics", topic, namespace)
+        if output == "yaml":
+            click.echo(yaml.dump(resource, default_flow_style=False))
+        elif output == "json":
+            click.echo(json.dumps(resource, indent=2))
     else:
         if native:
             native_command = (
@@ -208,9 +201,7 @@ def describe(
                 .format(port=KAFKA_PORT, topic=topic, cluster=cluster)
             )
         else:
-            os.system(
-                Kubectl().describe().kafkatopics(topic).namespace(namespace).build()
-            )
+            describe_resource("kafkatopics", topic, namespace)
 
 
 def delete(topic, cluster, namespace):

--- a/kfk/commands/users.py
+++ b/kfk/commands/users.py
@@ -1,4 +1,4 @@
-import os
+import json
 
 import click
 import yaml
@@ -13,10 +13,12 @@ from kfk.commons import (
     raise_exception_for_missing_options,
 )
 from kfk.config import STRIMZI_PATH, STRIMZI_VERSION
-from kfk.kubectl_command_builder import Kubectl
 from kfk.kubernetes_commons import (
     create_using_yaml,
     delete_using_yaml,
+    describe_resource,
+    get_resource,
+    list_resource,
     replace_using_yaml,
 )
 from kfk.option_extensions import NotRequiredIf, RequiredIf
@@ -169,15 +171,7 @@ def users(
 
 
 def list(cluster, namespace):
-    os.system(
-        Kubectl()
-        .get()
-        .kafkausers()
-        .label("strimzi.io/cluster={cluster}")
-        .namespace(namespace)
-        .build()
-        .format(cluster=cluster)
-    )
+    list_resource("kafkausers", namespace, label=f"strimzi.io/cluster={cluster}")
 
 
 def create(user, authentication_type, quota_tuple, cluster, namespace):
@@ -209,11 +203,13 @@ def create(user, authentication_type, quota_tuple, cluster, namespace):
 
 def describe(user, output, cluster, namespace):
     if output is not None:
-        os.system(
-            Kubectl().get().kafkausers(user).namespace(namespace).output(output).build()
-        )
+        resource = get_resource("kafkausers", user, namespace)
+        if output == "yaml":
+            click.echo(yaml.dump(resource, default_flow_style=False))
+        elif output == "json":
+            click.echo(json.dumps(resource, indent=2))
     else:
-        os.system(Kubectl().describe().kafkausers(user).namespace(namespace).build())
+        describe_resource("kafkausers", user, namespace)
 
 
 def delete(user, cluster, namespace):

--- a/kfk/commons.py
+++ b/kfk/commons.py
@@ -5,6 +5,7 @@ import tempfile
 from subprocess import call
 
 import click
+import yaml
 from jproperties import Properties
 
 from kfk.constants import (
@@ -18,6 +19,7 @@ from kfk.constants import (
     SPACE,
 )
 from kfk.kubectl_command_builder import Kubectl
+from kfk.kubernetes_commons import get_resource
 from kfk.utils import convert_string_to_type, get_list_by_split_string
 
 # TODO: Message string to messages.py
@@ -93,29 +95,18 @@ def delete_resource_config(config, dict_part, *converters):
 def resource_exists(
     resource_type=None, resource_name=None, cluster=None, namespace=None
 ):
-    command = Kubectl().get().resource(resource_type).namespace(namespace)
-
-    if cluster is not None:
-        command = command.label(f"strimzi.io/cluster={cluster}")
-
-    return resource_name in os.popen(command.build()).read()
+    try:
+        get_resource(resource_type, resource_name, namespace)
+        return True
+    except Exception:
+        return False
 
 
 def get_resource_yaml(
     resource_type=None, resource_name=None, cluster=None, namespace=None
 ):
-    command = (
-        Kubectl()
-        .get()
-        .resource(resource_type, resource_name)
-        .namespace(namespace)
-        .output("yaml")
-    )
-
-    if cluster is not None:
-        command = command.label(f"strimzi.io/cluster={cluster}")
-
-    return os.popen(command.build()).read()
+    resource = get_resource(resource_type, resource_name, namespace)
+    return yaml.dump(resource)
 
 
 def get_resource_as_stream(

--- a/kfk/kubernetes_commons.py
+++ b/kfk/kubernetes_commons.py
@@ -9,11 +9,25 @@ import yaml
 from kubernetes import client, config
 
 STRIMZI_GROUP = "kafka.strimzi.io"
-STRIMZI_VERSION = "v1"
 
 config.load_kube_config()
 api_client = client.ApiClient()
 custom_objects_api = client.CustomObjectsApi(api_client)
+
+
+def _detect_strimzi_api_version():
+    try:
+        api_ext = client.ApiextensionsV1Api(api_client)
+        crd = api_ext.read_custom_resource_definition("kafkas.kafka.strimzi.io")
+        for v in crd.spec.versions:
+            if v.served:
+                return v.name
+    except Exception:
+        pass
+    return "v1"
+
+
+STRIMZI_API_VERSION = _detect_strimzi_api_version()
 
 
 def yaml_object_argument_filter(func):
@@ -108,7 +122,7 @@ def replace_using_yaml(file_path, namespace):
 def list_resource(resource_type, namespace, label=None):
     result = custom_objects_api.list_namespaced_custom_object(
         group=STRIMZI_GROUP,
-        version=STRIMZI_VERSION,
+        version=STRIMZI_API_VERSION,
         namespace=namespace,
         plural=resource_type,
         label_selector=label or "",
@@ -134,7 +148,7 @@ def list_resource(resource_type, namespace, label=None):
 def get_resource(resource_type, resource_name, namespace):
     return custom_objects_api.get_namespaced_custom_object(
         group=STRIMZI_GROUP,
-        version=STRIMZI_VERSION,
+        version=STRIMZI_API_VERSION,
         namespace=namespace,
         plural=resource_type,
         name=resource_name,

--- a/kfk/kubernetes_commons.py
+++ b/kfk/kubernetes_commons.py
@@ -4,11 +4,16 @@ import re
 import sys
 from os import path
 
+import click
 import yaml
 from kubernetes import client, config
 
+STRIMZI_GROUP = "kafka.strimzi.io"
+STRIMZI_VERSION = "v1"
+
 config.load_kube_config()
 api_client = client.ApiClient()
+custom_objects_api = client.CustomObjectsApi(api_client)
 
 
 def yaml_object_argument_filter(func):
@@ -98,6 +103,97 @@ def replace_using_yaml(file_path, namespace):
         verbose=True,
         namespace=namespace,
     )
+
+
+def list_resource(resource_type, namespace, label=None):
+    result = custom_objects_api.list_namespaced_custom_object(
+        group=STRIMZI_GROUP,
+        version=STRIMZI_VERSION,
+        namespace=namespace,
+        plural=resource_type,
+        label_selector=label or "",
+    )
+    items = result.get("items", [])
+    if not items:
+        click.echo(f"No resources found in {namespace} namespace.")
+        return
+
+    header = f"{'NAME':<40} {'READY':<10}"
+    click.echo(header)
+    for item in items:
+        name = item["metadata"]["name"]
+        conditions = item.get("status", {}).get("conditions", [])
+        ready = "Unknown"
+        for condition in conditions:
+            if condition.get("type") == "Ready":
+                ready = condition.get("status", "Unknown")
+                break
+        click.echo(f"{name:<40} {ready:<10}")
+
+
+def get_resource(resource_type, resource_name, namespace):
+    return custom_objects_api.get_namespaced_custom_object(
+        group=STRIMZI_GROUP,
+        version=STRIMZI_VERSION,
+        namespace=namespace,
+        plural=resource_type,
+        name=resource_name,
+    )
+
+
+def describe_resource(resource_type, resource_name, namespace):
+    resource = get_resource(resource_type, resource_name, namespace)
+    metadata = resource.get("metadata", {})
+    spec = resource.get("spec", {})
+    status = resource.get("status", {})
+
+    click.echo(f"Name:         {metadata.get('name', '')}")
+    click.echo(f"Namespace:    {metadata.get('namespace', '')}")
+    click.echo(f"Kind:         {resource.get('kind', '')}")
+    click.echo(f"API Version:  {resource.get('apiVersion', '')}")
+
+    labels = metadata.get("labels", {})
+    if labels:
+        click.echo("Labels:")
+        for k, v in labels.items():
+            click.echo(f"              {k}={v}")
+
+    annotations = metadata.get("annotations", {})
+    if annotations:
+        click.echo("Annotations:")
+        for k, v in annotations.items():
+            click.echo(f"              {k}={v}")
+
+    click.echo(f"Creation Timestamp:  {metadata.get('creationTimestamp', '')}")
+    click.echo(f"Generation:          {metadata.get('generation', '')}")
+
+    if spec:
+        click.echo("Spec:")
+        click.echo(_format_dict(spec, indent=2))
+
+    if status:
+        click.echo("Status:")
+        click.echo(_format_dict(status, indent=2))
+
+
+def _format_dict(d, indent=0):
+    lines = []
+    prefix = " " * indent
+    for key, value in d.items():
+        if isinstance(value, dict):
+            lines.append(f"{prefix}{key}:")
+            lines.append(_format_dict(value, indent + 2))
+        elif isinstance(value, list):
+            lines.append(f"{prefix}{key}:")
+            for item in value:
+                if isinstance(item, dict):
+                    lines.append(f"{prefix}  -")
+                    lines.append(_format_dict(item, indent + 4))
+                else:
+                    lines.append(f"{prefix}  - {item}")
+        else:
+            lines.append(f"{prefix}{key}: {value}")
+    return "\n".join(lines)
 
 
 def _operate_using_yaml(

--- a/kfk/kubernetes_commons.py
+++ b/kfk/kubernetes_commons.py
@@ -8,6 +8,8 @@ import click
 import yaml
 from kubernetes import client, config
 
+from kfk.utils import format_dict_as_text
+
 STRIMZI_GROUP = "kafka.strimzi.io"
 
 config.load_kube_config()
@@ -183,31 +185,11 @@ def describe_resource(resource_type, resource_name, namespace):
 
     if spec:
         click.echo("Spec:")
-        click.echo(_format_dict(spec, indent=2))
+        click.echo(format_dict_as_text(spec, indent=2))
 
     if status:
         click.echo("Status:")
-        click.echo(_format_dict(status, indent=2))
-
-
-def _format_dict(d, indent=0):
-    lines = []
-    prefix = " " * indent
-    for key, value in d.items():
-        if isinstance(value, dict):
-            lines.append(f"{prefix}{key}:")
-            lines.append(_format_dict(value, indent + 2))
-        elif isinstance(value, list):
-            lines.append(f"{prefix}{key}:")
-            for item in value:
-                if isinstance(item, dict):
-                    lines.append(f"{prefix}  -")
-                    lines.append(_format_dict(item, indent + 4))
-                else:
-                    lines.append(f"{prefix}  - {item}")
-        else:
-            lines.append(f"{prefix}{key}: {value}")
-    return "\n".join(lines)
+        click.echo(format_dict_as_text(status, indent=2))
 
 
 def _operate_using_yaml(

--- a/kfk/utils.py
+++ b/kfk/utils.py
@@ -57,3 +57,23 @@ def is_valid_url(url):
     )
 
     return re.match(regex, url) is not None
+
+
+def format_dict_as_text(d, indent=0):
+    lines = []
+    prefix = " " * indent
+    for key, value in d.items():
+        if isinstance(value, dict):
+            lines.append(f"{prefix}{key}:")
+            lines.append(format_dict_as_text(value, indent + 2))
+        elif isinstance(value, list):
+            lines.append(f"{prefix}{key}:")
+            for item in value:
+                if isinstance(item, dict):
+                    lines.append(f"{prefix}  -")
+                    lines.append(format_dict_as_text(item, indent + 4))
+                else:
+                    lines.append(f"{prefix}  - {item}")
+        else:
+            lines.append(f"{prefix}{key}: {value}")
+    return "\n".join(lines)

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -22,33 +22,32 @@ class TestKfkClusters(TestCase):
         assert result.exit_code == 1
         assert "Missing options: kfk clusters" in result.output
 
-    @mock.patch("kfk.commands.clusters.os")
-    def test_list_clusters(self, mock_os):
+    @mock.patch("kfk.commands.clusters.list_resource")
+    def test_list_clusters(self, mock_list_resource):
         result = self.runner.invoke(kfk, ["clusters", "--list", "-n", self.namespace])
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().get().kafkas().namespace(self.namespace).build()
-        )
+        mock_list_resource.assert_called_with("kafkas", self.namespace)
 
-    @mock.patch("kfk.commands.clusters.os")
-    def test_list_clusters_all_namespaces(self, mock_os):
+    @mock.patch("kfk.commands.clusters.list_resource")
+    def test_list_clusters_all_namespaces(self, mock_list_resource):
         result = self.runner.invoke(kfk, ["clusters", "--list"])
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(Kubectl().get().kafkas().namespace().build())
+        mock_list_resource.assert_called_with("kafkas", None)
 
-    @mock.patch("kfk.commands.clusters.os")
-    def test_describe_cluster(self, mock_os):
+    @mock.patch("kfk.commands.clusters.describe_resource")
+    def test_describe_cluster(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             ["clusters", "--describe", "--cluster", self.cluster, "-n", self.namespace],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().describe().kafkas(self.cluster).namespace(self.namespace).build()
+        mock_describe_resource.assert_called_with(
+            "kafkas", self.cluster, self.namespace
         )
 
-    @mock.patch("kfk.commands.clusters.os")
-    def test_describe_cluster_output_yaml(self, mock_os):
+    @mock.patch("kfk.commands.clusters.get_resource")
+    def test_describe_cluster_output_yaml(self, mock_get_resource):
+        mock_get_resource.return_value = {"metadata": {"name": self.cluster}}
         result = self.runner.invoke(
             kfk,
             [
@@ -63,14 +62,7 @@ class TestKfkClusters(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkas(self.cluster)
-            .namespace(self.namespace)
-            .output("yaml")
-            .build()
-        )
+        mock_get_resource.assert_called_with("kafkas", self.cluster, self.namespace)
 
     @mock.patch("kfk.commands.clusters.os")
     def test_alter_cluster_without_parameters(self, mock_os):

--- a/tests/test_configs_command.py
+++ b/tests/test_configs_command.py
@@ -158,8 +158,8 @@ class TestKfkConfigs(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
-    @mock.patch("kfk.commands.topics.os")
-    def test_describe_topic_config(self, mock_os):
+    @mock.patch("kfk.commands.topics.describe_resource")
+    def test_describe_topic_config(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             [
@@ -176,12 +176,8 @@ class TestKfkConfigs(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .describe()
-            .kafkatopics(self.topic)
-            .namespace(self.namespace)
-            .build()
+        mock_describe_resource.assert_called_with(
+            "kafkatopics", self.topic, self.namespace
         )
 
     @mock.patch("kfk.commands.configs.os")
@@ -326,8 +322,8 @@ class TestKfkConfigs(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
-    @mock.patch("kfk.commands.users.os")
-    def test_describe_user_config(self, mock_os):
+    @mock.patch("kfk.commands.users.describe_resource")
+    def test_describe_user_config(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             [
@@ -344,8 +340,8 @@ class TestKfkConfigs(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().describe().kafkausers(self.user).namespace(self.namespace).build()
+        mock_describe_resource.assert_called_with(
+            "kafkausers", self.user, self.namespace
         )
 
     @mock.patch("kfk.commands.configs.os")
@@ -458,8 +454,8 @@ class TestKfkConfigs(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
-    @mock.patch("kfk.commands.clusters.os")
-    def test_describe_broker_config(self, mock_os):
+    @mock.patch("kfk.commands.clusters.describe_resource")
+    def test_describe_broker_config(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             [
@@ -476,8 +472,8 @@ class TestKfkConfigs(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().describe().kafkas(self.cluster).namespace(self.namespace).build()
+        mock_describe_resource.assert_called_with(
+            "kafkas", self.cluster, self.namespace
         )
 
     @mock.patch("kfk.commons.get_resource_yaml")

--- a/tests/test_connect_clusters_command.py
+++ b/tests/test_connect_clusters_command.py
@@ -430,41 +430,34 @@ class TestKfkConnect(TestCase):
 
         assert mock_connectors_create_using_yaml.call_count == 2
 
-    @mock.patch("kfk.commands.connect.clusters.os")
-    def test_list_clusters(self, mock_os):
+    @mock.patch("kfk.commands.connect.clusters.list_resource")
+    def test_list_clusters(self, mock_list_resource):
         result = self.runner.invoke(
             connect, ["clusters", "--list", "-n", self.namespace]
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().get().kafkaconnects().namespace(self.namespace).build()
-        )
+        mock_list_resource.assert_called_with("kafkaconnects", self.namespace)
 
-    @mock.patch("kfk.commands.connect.clusters.os")
-    def test_list_clusters_all_namespaces(self, mock_os):
+    @mock.patch("kfk.commands.connect.clusters.list_resource")
+    def test_list_clusters_all_namespaces(self, mock_list_resource):
         result = self.runner.invoke(connect, ["clusters", "--list"])
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().get().kafkaconnects().namespace().build()
-        )
+        mock_list_resource.assert_called_with("kafkaconnects", None)
 
-    @mock.patch("kfk.commands.connect.clusters.os")
-    def test_describe_cluster(self, mock_os):
+    @mock.patch("kfk.commands.connect.clusters.describe_resource")
+    def test_describe_cluster(self, mock_describe_resource):
         result = self.runner.invoke(
             connect,
             ["clusters", "--describe", "--cluster", self.cluster, "-n", self.namespace],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .describe()
-            .kafkaconnects(self.cluster)
-            .namespace(self.namespace)
-            .build()
+        mock_describe_resource.assert_called_with(
+            "kafkaconnects", self.cluster, self.namespace
         )
 
-    @mock.patch("kfk.commands.connect.clusters.os")
-    def test_describe_cluster_output_yaml(self, mock_os):
+    @mock.patch("kfk.commands.connect.clusters.get_resource")
+    def test_describe_cluster_output_yaml(self, mock_get_resource):
+        mock_get_resource.return_value = {"metadata": {"name": self.cluster}}
         result = self.runner.invoke(
             connect,
             [
@@ -479,13 +472,8 @@ class TestKfkConnect(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkaconnects(self.cluster)
-            .namespace(self.namespace)
-            .output("yaml")
-            .build()
+        mock_get_resource.assert_called_with(
+            "kafkaconnects", self.cluster, self.namespace
         )
 
     @mock.patch("kfk.commands.connect.clusters.click.confirm")

--- a/tests/test_connect_connectors_command.py
+++ b/tests/test_connect_connectors_command.py
@@ -3,7 +3,6 @@ from unittest import TestCase, mock
 from click.testing import CliRunner
 
 from kfk.commands.connect.connectors import connect
-from kfk.kubectl_command_builder import Kubectl
 
 STRIMZI_PATH = "tests/files/strimzi"
 
@@ -32,24 +31,20 @@ class TestKfkConnectors(TestCase):
         assert result.exit_code == 1
         assert "Missing options: kfk connectors" in result.output
 
-    @mock.patch("kfk.commands.connect.connectors.os")
-    def test_list_connectors(self, mock_os):
+    @mock.patch("kfk.commands.connect.connectors.list_resource")
+    def test_list_connectors(self, mock_list_resource):
         result = self.runner.invoke(
             connect, ["connectors", "--list", "-c", self.cluster, "-n", self.namespace]
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkaconnectors()
-            .label("strimzi.io/cluster={cluster}")
-            .namespace(self.namespace)
-            .build()
-            .format(cluster=self.cluster)
+        mock_list_resource.assert_called_with(
+            "kafkaconnectors",
+            self.namespace,
+            label=f"strimzi.io/cluster={self.cluster}",
         )
 
-    @mock.patch("kfk.commands.connect.connectors.os")
-    def test_describe_connector(self, mock_os):
+    @mock.patch("kfk.commands.connect.connectors.describe_resource")
+    def test_describe_connector(self, mock_describe_resource):
         result = self.runner.invoke(
             connect,
             [
@@ -64,16 +59,13 @@ class TestKfkConnectors(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .describe()
-            .kafkaconnectors(self.connector)
-            .namespace(self.namespace)
-            .build()
+        mock_describe_resource.assert_called_with(
+            "kafkaconnectors", self.connector, self.namespace
         )
 
-    @mock.patch("kfk.commands.connect.connectors.os")
-    def test_describe_connector_output_yaml(self, mock_os):
+    @mock.patch("kfk.commands.connect.connectors.get_resource")
+    def test_describe_connector_output_yaml(self, mock_get_resource):
+        mock_get_resource.return_value = {"metadata": {"name": self.connector}}
         result = self.runner.invoke(
             connect,
             [
@@ -90,13 +82,8 @@ class TestKfkConnectors(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkaconnectors(self.connector)
-            .namespace(self.namespace)
-            .output("yaml")
-            .build()
+        mock_get_resource.assert_called_with(
+            "kafkaconnectors", self.connector, self.namespace
         )
 
     @mock.patch("kfk.commands.connect.connectors.delete_using_yaml")

--- a/tests/test_topics_command.py
+++ b/tests/test_topics_command.py
@@ -24,24 +24,20 @@ class TestKfkTopics(TestCase):
         assert result.exit_code == 1
         assert "Missing options: kfk topics" in result.output
 
-    @mock.patch("kfk.commands.topics.os")
-    def test_list_topics(self, mock_os):
+    @mock.patch("kfk.commands.topics.list_resource")
+    def test_list_topics(self, mock_list_resource):
         result = self.runner.invoke(
             kfk, ["topics", "--list", "-c", self.cluster, "-n", self.namespace]
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkatopics()
-            .label("strimzi.io/cluster={cluster}")
-            .namespace(self.namespace)
-            .build()
-            .format(cluster=self.cluster)
+        mock_list_resource.assert_called_with(
+            "kafkatopics",
+            self.namespace,
+            label=f"strimzi.io/cluster={self.cluster}",
         )
 
-    @mock.patch("kfk.commands.topics.os")
-    def test_describe_topic(self, mock_os):
+    @mock.patch("kfk.commands.topics.describe_resource")
+    def test_describe_topic(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             [
@@ -56,16 +52,13 @@ class TestKfkTopics(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .describe()
-            .kafkatopics(self.topic)
-            .namespace(self.namespace)
-            .build()
+        mock_describe_resource.assert_called_with(
+            "kafkatopics", self.topic, self.namespace
         )
 
-    @mock.patch("kfk.commands.topics.os")
-    def test_describe_topic_output_yaml(self, mock_os):
+    @mock.patch("kfk.commands.topics.get_resource")
+    def test_describe_topic_output_yaml(self, mock_get_resource):
+        mock_get_resource.return_value = {"metadata": {"name": self.topic}}
         result = self.runner.invoke(
             kfk,
             [
@@ -82,14 +75,7 @@ class TestKfkTopics(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkatopics(self.topic)
-            .namespace(self.namespace)
-            .output("yaml")
-            .build()
-        )
+        mock_get_resource.assert_called_with("kafkatopics", self.topic, self.namespace)
 
     @mock.patch("kfk.commands.topics.os")
     def test_describe_topic_native(self, mock_os):

--- a/tests/test_users_command.py
+++ b/tests/test_users_command.py
@@ -3,7 +3,6 @@ from unittest import TestCase, mock
 from click.testing import CliRunner
 
 from kfk.commands.users import kfk
-from kfk.kubectl_command_builder import Kubectl
 
 
 class TestKfkUsers(TestCase):
@@ -21,24 +20,20 @@ class TestKfkUsers(TestCase):
         assert result.exit_code == 1
         assert "Missing options: kfk users" in result.output
 
-    @mock.patch("kfk.commands.users.os")
-    def test_list_users(self, mock_os):
+    @mock.patch("kfk.commands.users.list_resource")
+    def test_list_users(self, mock_list_resource):
         result = self.runner.invoke(
             kfk, ["users", "--list", "-c", self.cluster, "-n", self.namespace]
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkausers()
-            .label("strimzi.io/cluster={cluster}")
-            .namespace(self.namespace)
-            .build()
-            .format(cluster=self.cluster)
+        mock_list_resource.assert_called_with(
+            "kafkausers",
+            self.namespace,
+            label=f"strimzi.io/cluster={self.cluster}",
         )
 
-    @mock.patch("kfk.commands.users.os")
-    def test_describe_user(self, mock_os):
+    @mock.patch("kfk.commands.users.describe_resource")
+    def test_describe_user(self, mock_describe_resource):
         result = self.runner.invoke(
             kfk,
             [
@@ -53,12 +48,13 @@ class TestKfkUsers(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl().describe().kafkausers(self.user).namespace(self.namespace).build()
+        mock_describe_resource.assert_called_with(
+            "kafkausers", self.user, self.namespace
         )
 
-    @mock.patch("kfk.commands.users.os")
-    def test_describe_user_output_yaml(self, mock_os):
+    @mock.patch("kfk.commands.users.get_resource")
+    def test_describe_user_output_yaml(self, mock_get_resource):
+        mock_get_resource.return_value = {"metadata": {"name": self.user}}
         result = self.runner.invoke(
             kfk,
             [
@@ -75,14 +71,7 @@ class TestKfkUsers(TestCase):
             ],
         )
         assert result.exit_code == 0
-        mock_os.system.assert_called_with(
-            Kubectl()
-            .get()
-            .kafkausers(self.user)
-            .namespace(self.namespace)
-            .output("yaml")
-            .build()
-        )
+        mock_get_resource.assert_called_with("kafkausers", self.user, self.namespace)
 
     @mock.patch("kfk.commands.users.STRIMZI_PATH", "tests/files/strimzi")
     @mock.patch("kfk.commands.users.create_temp_file")


### PR DESCRIPTION
## Summary

Part of #118 (Phase 1 of 2)

This PR replaces `os.system(Kubectl()...)` calls for **get**, **describe**, and **list** operations with native Python Kubernetes client calls using `CustomObjectsApi`. This is part of the ongoing effort to eliminate kubectl shell-outs in favor of the Python K8s client.

### What changed

- **`kfk/kubernetes_commons.py`**: Added three new public functions:
  - `list_resource(resource_type, namespace, label=None)` - Lists Strimzi CRDs with formatted table output
  - `get_resource(resource_type, resource_name, namespace)` - Returns a single CRD as a dict
  - `describe_resource(resource_type, resource_name, namespace)` - Prints kubectl-describe-like output
  - `_detect_strimzi_api_version()` - Auto-detects the served CRD API version (`v1` or `v1beta2`)

- **`kfk/commons.py`**: Updated `resource_exists()` and `get_resource_yaml()` to use the new K8s client functions instead of `os.popen(Kubectl()...)`

- **Command files updated** (5 files):
  - `kfk/commands/clusters.py` - list/describe operations
  - `kfk/commands/topics.py` - list/describe operations
  - `kfk/commands/users.py` - list/describe operations
  - `kfk/commands/connect/clusters.py` - list/describe operations
  - `kfk/commands/connect/connectors.py` - list/describe operations

- **Test files updated** (6 files):
  - Tests now mock `list_resource`, `get_resource`, `describe_resource` instead of `os.system` with `Kubectl()` command strings

### What is NOT in scope (Phase 2)

The following operations still use `os.system(Kubectl()...)` and will be addressed in a follow-up PR:
- `kubectl edit` (2 calls - clusters.py, connect/clusters.py) - requires interactive editor
- `kubectl exec` (5 calls - topics.py, configs.py, console.py, acls.py) - requires interactive TTY
- `kubectl cp` (2 calls - commons.py) - file transfer to pods

## Test plan

- [x] `pytest tests/` - 154 passed, 2 pre-existing failures in test_config.py (ARM/x86 mock issue, unrelated)
- [x] CI builds passed (Python 3.11, 3.12, 3.13, 3.14)
- [x] `kfk clusters --list -n kafka` - lists Kafka clusters with NAME/READY table
- [x] `kfk clusters --describe --cluster test-cluster -n kafka` - kubectl-describe-like output
- [x] `kfk clusters --describe --cluster test-cluster -n kafka -o yaml` - YAML output
- [x] `kfk clusters --describe --cluster test-cluster -n kafka -o json` - JSON output
- [x] `kfk topics --list -c test-cluster -n kafka` - lists topics
- [x] `kfk topics --describe --topic test-topic -c test-cluster -n kafka` - describes topic
- [x] `kfk topics --describe --topic test-topic -c test-cluster -n kafka -o yaml` - YAML output
- [x] `kfk users --list -c test-cluster -n kafka` - lists users
- [x] `kfk users --describe --user test-user -c test-cluster -n kafka` - describes user
- [x] `kfk connect clusters --list -n kafka` - lists connect clusters (no resources found)
- [x] `kfk connect connectors --list -c test-cluster -n kafka` - lists connectors (no resources found)
- [x] `kfk clusters --alter --cluster test-cluster -n kafka` (no config params) - kubectl edit still works
- [x] Auto-detect CRD API version works with Strimzi 0.41.0 (v1beta2)