### PR TITLE
Add --listener-auth flag for cluster listener authentication

### DIFF
--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -45,6 +45,13 @@ from kfk.utils import convert_string_to_type
     multiple=True,
 )
 @click.option(
+    "--listener-auth",
+    help=(
+        "Authentication config for the listener being added."
+        " Format: type=T,validIssuerUri=U,clientId=C"
+    ),
+)
+@click.option(
     "--add-listener",
     help=(
         "A listener to be added to the cluster."
@@ -109,16 +116,21 @@ def clusters(
     config,
     delete_config,
     add_listener,
+    listener_auth,
     delete_listener,
     output,
     namespace,
     is_yes,
 ):
     """Creates, alters, deletes, describes Kafka cluster(s)."""
+    if listener_auth and len(add_listener) == 0:
+        raise click.UsageError("--listener-auth requires --add-listener.")
     if is_list:
         list(namespace)
     elif is_create:
-        create(cluster, replicas, config, add_listener, namespace, is_yes)
+        create(
+            cluster, replicas, config, add_listener, listener_auth, namespace, is_yes
+        )
     elif is_describe:
         describe(cluster, output, namespace)
     elif is_delete:
@@ -130,6 +142,7 @@ def clusters(
             config,
             delete_config,
             add_listener,
+            listener_auth,
             delete_listener,
             namespace,
         )
@@ -141,7 +154,7 @@ def list(namespace):
     list_resource("kafkas", namespace)
 
 
-def create(cluster, replicas, config, add_listener, namespace, is_yes):
+def create(cluster, replicas, config, add_listener, listener_auth, namespace, is_yes):
     with open(
         "{strimzi_path}/examples/kafka/kafka-ephemeral.yaml".format(
             strimzi_path=STRIMZI_PATH
@@ -163,7 +176,7 @@ def create(cluster, replicas, config, add_listener, namespace, is_yes):
 
         _add_config_if_provided(config, kafka_dict)
 
-        _add_listeners_if_provided(add_listener, kafka_dict)
+        _add_listeners_if_provided(add_listener, kafka_dict, listener_auth)
 
         cluster_yaml = yaml.dump_all(docs)
         cluster_temp_file = create_temp_file(cluster_yaml)
@@ -227,6 +240,7 @@ def alter(
     config,
     delete_config,
     add_listener,
+    listener_auth,
     delete_listener,
     namespace,
 ):
@@ -255,7 +269,7 @@ def alter(
                     delete_config, cluster_dict["spec"]["kafka"]["config"]
                 )
 
-        _add_listeners_if_provided(add_listener, cluster_dict)
+        _add_listeners_if_provided(add_listener, cluster_dict, listener_auth)
         _delete_listeners_if_provided(delete_listener, cluster_dict)
 
         cluster_yaml = yaml.dump(cluster_dict)
@@ -342,11 +356,21 @@ def _parse_listener(listener_str):
     return listener
 
 
-def _add_listeners_if_provided(add_listener, cluster_dict):
+def _parse_listener_auth(listener_auth):
+    auth = {}
+    for part in get_config_list(listener_auth):
+        key, _, value = part.partition("=")
+        auth[key] = convert_string_to_type(value)
+    return auth
+
+
+def _add_listeners_if_provided(add_listener, cluster_dict, listener_auth=None):
     if len(add_listener) > 0:
         listeners = cluster_dict["spec"]["kafka"].setdefault("listeners", [])
         for listener_str in add_listener:
             new_listener = _parse_listener(listener_str)
+            if listener_auth:
+                new_listener["authentication"] = _parse_listener_auth(listener_auth)
             for existing in listeners:
                 if existing["name"] == new_listener["name"]:
                     existing.update(new_listener)

--- a/kfk/commands/configs.py
+++ b/kfk/commands/configs.py
@@ -129,6 +129,7 @@ def configs(
                 add_config_list,
                 delete_config_list,
                 (),
+                None,
                 (),
                 namespace,
             )

--- a/tests/files/yaml/kafka-ephemeral_with_custom_auth_listener.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_custom_auth_listener.yaml
@@ -1,0 +1,33 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    - authentication:
+        sasl: true
+        type: custom
+      name: oauth
+      port: 9094
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/files/yaml/kafka-ephemeral_with_scram_listener.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_scram_listener.yaml
@@ -1,0 +1,28 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - authentication:
+        type: scram-sha-512
+      name: tls
+      port: 9093
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -673,3 +673,90 @@ class TestKfkClusters(TestCase):
             assert expected_kafka_yaml == result_kafka_yaml
 
         mock_create_using_yaml.assert_called_once()
+
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_add_listener_and_auth(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--add-listener",
+                    "name=oauth,port=9094,type=internal,tls=true",
+                    "--listener-auth",
+                    "type=custom,sasl=true",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/kafka-ephemeral_with_custom_auth_listener.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_update_listener_auth(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--add-listener",
+                    "name=tls",
+                    "--listener-auth",
+                    "type=scram-sha-512",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/kafka-ephemeral_with_scram_listener.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    def test_listener_auth_without_add_listener_fails(self):
+        result = self.runner.invoke(
+            kfk,
+            [
+                "clusters",
+                "--alter",
+                "--listener-auth",
+                "type=custom",
+                "--cluster",
+                self.cluster,
+                "-n",
+                self.namespace,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--listener-auth requires --add-listener" in result.output


### PR DESCRIPTION
## Summary
- Add `--listener-auth` flag for cluster listener authentication configuration
- Supports all Strimzi 1.0.0 listener auth types: `tls`, `scram-sha-512`, `custom`
- `--listener-auth` requires `--add-listener` (runtime validation)
- Flat key=value format: `--listener-auth "type=custom,sasl=true"`

## Test plan
- [x] `test_alter_cluster_with_add_listener_and_auth` -- add new listener with authentication
- [x] `test_alter_cluster_with_update_listener_auth` -- add auth to existing listener
- [x] `test_listener_auth_without_add_listener_fails` -- validates runtime check
- [x] All 138 tests passing
- [x] pre-commit clean
- [x] Manual test on Minikube: `type=scram-sha-512`, `type=tls`, `type=custom,sasl=true`

Closes #96