### PR TITLE
Add cluster-level authorization support

### DIFF
--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -24,7 +24,7 @@ from kfk.kubernetes_commons import (
     replace_using_yaml,
 )
 from kfk.messages import Messages
-from kfk.option_extensions import NotRequiredIf
+from kfk.option_extensions import NotRequiredIf, RequiredIf
 from kfk.utils import parse_kv_string
 
 
@@ -51,6 +51,8 @@ from kfk.utils import parse_kv_string
     "--authorization-type",
     help="Authorization type for the cluster.",
     type=click.Choice(["simple", "custom", "none"], case_sensitive=True),
+    cls=RequiredIf,
+    options=["super_user"],
 )
 @click.option(
     "--listener-auth",
@@ -66,6 +68,8 @@ from kfk.utils import parse_kv_string
         " Format: name=X,port=N,type=T,tls=BOOL"
     ),
     multiple=True,
+    cls=RequiredIf,
+    options=["listener_auth"],
 )
 @click.option(
     "--delete-config",
@@ -133,10 +137,6 @@ def clusters(
     is_yes,
 ):
     """Creates, alters, deletes, describes Kafka cluster(s)."""
-    if listener_auth and len(add_listener) == 0:
-        raise click.UsageError("--listener-auth requires --add-listener.")
-    if len(super_user) > 0 and authorization_type is None:
-        raise click.UsageError("--super-user requires --authorization-type.")
     if is_list:
         list(namespace)
     elif is_create:

--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -43,6 +43,16 @@ from kfk.utils import parse_kv_string
     multiple=True,
 )
 @click.option(
+    "--super-user",
+    help="A super user for cluster authorization.",
+    multiple=True,
+)
+@click.option(
+    "--authorization-type",
+    help="Authorization type for the cluster.",
+    type=click.Choice(["simple", "custom", "none"], case_sensitive=True),
+)
+@click.option(
     "--listener-auth",
     help=(
         "Authentication config for the listener being added."
@@ -116,6 +126,8 @@ def clusters(
     add_listener,
     listener_auth,
     delete_listener,
+    authorization_type,
+    super_user,
     output,
     namespace,
     is_yes,
@@ -123,6 +135,8 @@ def clusters(
     """Creates, alters, deletes, describes Kafka cluster(s)."""
     if listener_auth and len(add_listener) == 0:
         raise click.UsageError("--listener-auth requires --add-listener.")
+    if len(super_user) > 0 and authorization_type is None:
+        raise click.UsageError("--super-user requires --authorization-type.")
     if is_list:
         list(namespace)
     elif is_create:
@@ -142,6 +156,8 @@ def clusters(
             add_listener,
             listener_auth,
             delete_listener,
+            authorization_type,
+            super_user,
             namespace,
         )
     else:
@@ -240,6 +256,8 @@ def alter(
     add_listener,
     listener_auth,
     delete_listener,
+    authorization_type,
+    super_user,
     namespace,
 ):
     has_changes = (
@@ -248,6 +266,7 @@ def alter(
         or len(add_listener) > 0
         or len(delete_listener) > 0
         or replicas is not None
+        or authorization_type is not None
     )
     if has_changes:
         stream = get_resource_as_stream(
@@ -269,6 +288,7 @@ def alter(
 
         _add_listeners_if_provided(add_listener, cluster_dict, listener_auth)
         _delete_listeners_if_provided(delete_listener, cluster_dict)
+        _set_authorization_if_provided(authorization_type, super_user, cluster_dict)
 
         cluster_yaml = yaml.dump(cluster_dict)
         cluster_temp_file = create_temp_file(cluster_yaml)
@@ -369,3 +389,14 @@ def _delete_listeners_if_provided(delete_listener, cluster_dict):
             for listener in listeners
             if listener["name"] not in delete_listener
         ]
+
+
+def _set_authorization_if_provided(authorization_type, super_user, cluster_dict):
+    if authorization_type is not None:
+        if authorization_type == "none":
+            cluster_dict["spec"]["kafka"].pop("authorization", None)
+        else:
+            auth = {"type": authorization_type}
+            if len(super_user) > 0:
+                auth["superUsers"] = [*super_user]
+            cluster_dict["spec"]["kafka"]["authorization"] = auth

--- a/kfk/commands/configs.py
+++ b/kfk/commands/configs.py
@@ -131,6 +131,8 @@ def configs(
                 (),
                 None,
                 (),
+                None,
+                (),
                 namespace,
             )
     else:

--- a/tests/files/yaml/kafka-ephemeral_authorization_removed.yaml
+++ b/tests/files/yaml/kafka-ephemeral_authorization_removed.yaml
@@ -1,0 +1,26 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/files/yaml/kafka-ephemeral_with_simple_authorization.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_simple_authorization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    authorization:
+      type: simple
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/files/yaml/kafka-ephemeral_with_simple_authorization_and_super_users.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_simple_authorization_and_super_users.yaml
@@ -1,0 +1,31 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    authorization:
+      superUsers:
+      - CN=admin
+      - user-2
+      type: simple
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -744,6 +744,129 @@ class TestKfkClusters(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_authorization_simple(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--authorization-type",
+                    "simple",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/kafka-ephemeral_with_simple_authorization.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_authorization_and_super_users(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--authorization-type",
+                    "simple",
+                    "--super-user",
+                    "CN=admin",
+                    "--super-user",
+                    "user-2",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/"
+                "kafka-ephemeral_with_simple_authorization_and_super_users.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_authorization_none(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open(
+            "tests/files/yaml/kafka-ephemeral_with_simple_authorization.yaml"
+        ) as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--authorization-type",
+                    "none",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/kafka-ephemeral_authorization_removed.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    def test_super_user_without_authorization_type_fails(self):
+        result = self.runner.invoke(
+            kfk,
+            [
+                "clusters",
+                "--alter",
+                "--super-user",
+                "CN=admin",
+                "--cluster",
+                self.cluster,
+                "-n",
+                self.namespace,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--super-user requires --authorization-type" in result.output
+
     def test_listener_auth_without_add_listener_fails(self):
         result = self.runner.invoke(
             kfk,

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -865,7 +865,7 @@ class TestKfkClusters(TestCase):
             ],
         )
         assert result.exit_code != 0
-        assert "--super-user requires --authorization-type" in result.output
+        assert "Missing option '--authorization-type'" in result.output
 
     def test_listener_auth_without_add_listener_fails(self):
         result = self.runner.invoke(
@@ -882,4 +882,4 @@ class TestKfkClusters(TestCase):
             ],
         )
         assert result.exit_code != 0
-        assert "--listener-auth requires --add-listener" in result.output
+        assert "Missing option '--add-listener'" in result.output


### PR DESCRIPTION
## Summary
- Add `--authorization-type` flag (simple/custom/none) and `--super-user` flag (repeatable) to `kfk clusters --alter`
- `--authorization-type simple` sets `spec.kafka.authorization.type: simple` (StandardAuthorizer, ACL-based)
- `--authorization-type custom` for custom authorizer class
- `--authorization-type none` removes authorization from the cluster
- `--super-user` adds super users to the authorization config (requires `--authorization-type`)
- Update `configs.py` to pass new params when calling `clusters.alter()`

## Test plan
- [x] `test_alter_cluster_with_authorization_simple`
- [x] `test_alter_cluster_with_authorization_and_super_users`
- [x] `test_alter_cluster_with_authorization_none` (remove)
- [x] `test_super_user_without_authorization_type_fails` (validation)
- [x] All 143 tests pass
- [x] pre-commit clean
- [x] Manual test on Minikube

Closes #95