### PR TITLE
Add --authorizer-class flag for custom authorization

### DIFF
--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -24,7 +24,7 @@ from kfk.kubernetes_commons import (
     replace_using_yaml,
 )
 from kfk.messages import Messages
-from kfk.option_extensions import NotRequiredIf, RequiredIf
+from kfk.option_extensions import NotRequiredIf, RequiredIf, RequiredIfValue
 from kfk.utils import parse_kv_string
 
 
@@ -45,6 +45,8 @@ from kfk.utils import parse_kv_string
 @click.option(
     "--authorizer-class",
     help="Fully qualified authorizer class name for custom authorization.",
+    cls=RequiredIfValue,
+    option_value_pairs={"authorization_type": "custom"},
 )
 @click.option(
     "--super-user",
@@ -56,7 +58,7 @@ from kfk.utils import parse_kv_string
     help="Authorization type for the cluster.",
     type=click.Choice(["simple", "custom", "none"], case_sensitive=True),
     cls=RequiredIf,
-    options=["super_user", "authorizer_class"],
+    options=["super_user"],
 )
 @click.option(
     "--listener-auth",

--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -43,6 +43,10 @@ from kfk.utils import parse_kv_string
     multiple=True,
 )
 @click.option(
+    "--authorizer-class",
+    help="Fully qualified authorizer class name for custom authorization.",
+)
+@click.option(
     "--super-user",
     help="A super user for cluster authorization.",
     multiple=True,
@@ -52,7 +56,7 @@ from kfk.utils import parse_kv_string
     help="Authorization type for the cluster.",
     type=click.Choice(["simple", "custom", "none"], case_sensitive=True),
     cls=RequiredIf,
-    options=["super_user"],
+    options=["super_user", "authorizer_class"],
 )
 @click.option(
     "--listener-auth",
@@ -132,6 +136,7 @@ def clusters(
     delete_listener,
     authorization_type,
     super_user,
+    authorizer_class,
     output,
     namespace,
     is_yes,
@@ -158,6 +163,7 @@ def clusters(
             delete_listener,
             authorization_type,
             super_user,
+            authorizer_class,
             namespace,
         )
     else:
@@ -258,6 +264,7 @@ def alter(
     delete_listener,
     authorization_type,
     super_user,
+    authorizer_class,
     namespace,
 ):
     has_changes = (
@@ -288,7 +295,9 @@ def alter(
 
         _add_listeners_if_provided(add_listener, cluster_dict, listener_auth)
         _delete_listeners_if_provided(delete_listener, cluster_dict)
-        _set_authorization_if_provided(authorization_type, super_user, cluster_dict)
+        _set_authorization_if_provided(
+            authorization_type, super_user, authorizer_class, cluster_dict
+        )
 
         cluster_yaml = yaml.dump(cluster_dict)
         cluster_temp_file = create_temp_file(cluster_yaml)
@@ -391,7 +400,9 @@ def _delete_listeners_if_provided(delete_listener, cluster_dict):
         ]
 
 
-def _set_authorization_if_provided(authorization_type, super_user, cluster_dict):
+def _set_authorization_if_provided(
+    authorization_type, super_user, authorizer_class, cluster_dict
+):
     if authorization_type is not None:
         if authorization_type == "none":
             cluster_dict["spec"]["kafka"].pop("authorization", None)
@@ -399,4 +410,6 @@ def _set_authorization_if_provided(authorization_type, super_user, cluster_dict)
             auth = {"type": authorization_type}
             if len(super_user) > 0:
                 auth["superUsers"] = [*super_user]
+            if authorizer_class is not None:
+                auth["authorizerClass"] = authorizer_class
             cluster_dict["spec"]["kafka"]["authorization"] = auth

--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -58,7 +58,7 @@ from kfk.utils import parse_kv_string
     help="Authorization type for the cluster.",
     type=click.Choice(["simple", "custom", "none"], case_sensitive=True),
     cls=RequiredIf,
-    options=["super_user"],
+    options=["super_user", "authorizer_class"],
 )
 @click.option(
     "--listener-auth",

--- a/kfk/commands/configs.py
+++ b/kfk/commands/configs.py
@@ -133,6 +133,7 @@ def configs(
                 (),
                 None,
                 (),
+                None,
                 namespace,
             )
     else:

--- a/kfk/option_extensions.py
+++ b/kfk/option_extensions.py
@@ -27,6 +27,29 @@ class NotRequiredIf(click.Option):
         return super(NotRequiredIf, self).handle_parse_result(ctx, opts, args)
 
 
+class RequiredIfValue(click.Option):
+
+    def __init__(self, *args, **kwargs):
+        self.option_value_pairs = kwargs.pop("option_value_pairs")
+        assert self.option_value_pairs, "'option_value_pairs' parameter required"
+        kwargs["help"] = (
+            kwargs.get("help", "")
+            + " This argument is required when %s"
+            % ", ".join(f"{k}={v}" for k, v in self.option_value_pairs.items())
+        ).strip()
+        super(RequiredIfValue, self).__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        for option, value in self.option_value_pairs.items():
+            if opts.get(option) == value:
+                self.required = True
+                break
+        else:
+            self.required = None
+
+        return super(RequiredIfValue, self).handle_parse_result(ctx, opts, args)
+
+
 class RequiredIf(click.Option):
     # TODO: Refactor here
 

--- a/tests/files/yaml/kafka-ephemeral_with_custom_authorization.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_custom_authorization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    authorization:
+      authorizerClass: io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer
+      type: custom
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -902,14 +902,14 @@ class TestKfkClusters(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
-    def test_authorizer_class_without_authorization_type_fails(self):
+    def test_custom_authorization_without_authorizer_class_fails(self):
         result = self.runner.invoke(
             kfk,
             [
                 "clusters",
                 "--alter",
-                "--authorizer-class",
-                "io.strimzi.SomeAuthorizer",
+                "--authorization-type",
+                "custom",
                 "--cluster",
                 self.cluster,
                 "-n",
@@ -917,7 +917,7 @@ class TestKfkClusters(TestCase):
             ],
         )
         assert result.exit_code != 0
-        assert "Missing option '--authorization-type'" in result.output
+        assert "Missing option '--authorizer-class'" in result.output
 
     def test_listener_auth_without_add_listener_fails(self):
         result = self.runner.invoke(

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -919,6 +919,23 @@ class TestKfkClusters(TestCase):
         assert result.exit_code != 0
         assert "Missing option '--authorizer-class'" in result.output
 
+    def test_authorizer_class_without_authorization_type_fails(self):
+        result = self.runner.invoke(
+            kfk,
+            [
+                "clusters",
+                "--alter",
+                "--authorizer-class",
+                "io.strimzi.SomeAuthorizer",
+                "--cluster",
+                self.cluster,
+                "-n",
+                self.namespace,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Missing option '--authorization-type'" in result.output
+
     def test_listener_auth_without_add_listener_fails(self):
         result = self.runner.invoke(
             kfk,

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -867,6 +867,58 @@ class TestKfkClusters(TestCase):
         assert result.exit_code != 0
         assert "Missing option '--authorization-type'" in result.output
 
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_custom_authorization_and_authorizer_class(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--authorization-type",
+                    "custom",
+                    "--authorizer-class",
+                    "io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/kafka-ephemeral_with_custom_authorization.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    def test_authorizer_class_without_authorization_type_fails(self):
+        result = self.runner.invoke(
+            kfk,
+            [
+                "clusters",
+                "--alter",
+                "--authorizer-class",
+                "io.strimzi.SomeAuthorizer",
+                "--cluster",
+                self.cluster,
+                "-n",
+                self.namespace,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Missing option '--authorization-type'" in result.output
+
     def test_listener_auth_without_add_listener_fails(self):
         result = self.runner.invoke(
             kfk,


### PR DESCRIPTION
## Summary
- Add `--authorizer-class` flag to specify the fully qualified authorizer class name when using `--authorization-type custom`
- Uses `RequiredIf` to enforce `--authorization-type` is present when `--authorizer-class` is used
- Sets `spec.kafka.authorization.authorizerClass` in the Kafka CRD

### Usage
```bash
kfk clusters --alter --cluster my-cluster -n kafka \
  --authorization-type custom \
  --authorizer-class io.strimzi.kafka.oauth.server.authorizer.KeycloakAuthorizer
```

## Test plan
- [x] `test_alter_cluster_with_custom_authorization_and_authorizer_class`
- [x] `test_authorizer_class_without_authorization_type_fails`
- [x] All 145 tests pass
- [x] pre-commit clean

Closes #142