### PR TITLE
Add --listener-config flag for custom listener authentication

### DIFF
--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -61,7 +61,7 @@ from kfk.utils import parse_kv_string
     options=["super_user", "authorizer_class"],
 )
 @click.option(
-    "--listener-config",
+    "--listener-auth-config",
     help="Key-value config for custom listener authentication.",
     multiple=True,
 )
@@ -72,7 +72,7 @@ from kfk.utils import parse_kv_string
         " Format: type=T,validIssuerUri=U,clientId=C"
     ),
     cls=RequiredIf,
-    options=["listener_config"],
+    options=["listener_auth_config"],
 )
 @click.option(
     "--add-listener",
@@ -82,7 +82,7 @@ from kfk.utils import parse_kv_string
     ),
     multiple=True,
     cls=RequiredIf,
-    options=["listener_auth", "listener_config"],
+    options=["listener_auth", "listener_auth_config"],
 )
 @click.option(
     "--delete-config",
@@ -142,7 +142,7 @@ def clusters(
     delete_config,
     add_listener,
     listener_auth,
-    listener_config,
+    listener_auth_config,
     delete_listener,
     authorization_type,
     super_user,
@@ -170,7 +170,7 @@ def clusters(
             delete_config,
             add_listener,
             listener_auth,
-            listener_config,
+            listener_auth_config,
             delete_listener,
             authorization_type,
             super_user,
@@ -272,7 +272,7 @@ def alter(
     delete_config,
     add_listener,
     listener_auth,
-    listener_config,
+    listener_auth_config,
     delete_listener,
     authorization_type,
     super_user,
@@ -306,7 +306,7 @@ def alter(
                 )
 
         _add_listeners_if_provided(
-            add_listener, cluster_dict, listener_auth, listener_config
+            add_listener, cluster_dict, listener_auth, listener_auth_config
         )
         _delete_listeners_if_provided(delete_listener, cluster_dict)
         _set_authorization_if_provided(
@@ -390,7 +390,7 @@ def _add_config_if_provided(config, cluster_dict):
 
 
 def _add_listeners_if_provided(
-    add_listener, cluster_dict, listener_auth=None, listener_config=()
+    add_listener, cluster_dict, listener_auth=None, listener_auth_config=()
 ):
     if len(add_listener) > 0:
         listeners = cluster_dict["spec"]["kafka"].setdefault("listeners", [])
@@ -398,10 +398,10 @@ def _add_listeners_if_provided(
             new_listener = parse_kv_string(listener_str)
             if listener_auth:
                 new_listener["authentication"] = parse_kv_string(listener_auth)
-                if len(listener_config) > 0:
+                if len(listener_auth_config) > 0:
                     new_listener["authentication"]["listenerConfig"] = {}
                     add_kv_config_to_resource(
-                        listener_config,
+                        listener_auth_config,
                         new_listener["authentication"]["listenerConfig"],
                     )
             for existing in listeners:

--- a/kfk/commands/clusters.py
+++ b/kfk/commands/clusters.py
@@ -61,11 +61,18 @@ from kfk.utils import parse_kv_string
     options=["super_user", "authorizer_class"],
 )
 @click.option(
+    "--listener-config",
+    help="Key-value config for custom listener authentication.",
+    multiple=True,
+)
+@click.option(
     "--listener-auth",
     help=(
         "Authentication config for the listener being added."
         " Format: type=T,validIssuerUri=U,clientId=C"
     ),
+    cls=RequiredIf,
+    options=["listener_config"],
 )
 @click.option(
     "--add-listener",
@@ -75,7 +82,7 @@ from kfk.utils import parse_kv_string
     ),
     multiple=True,
     cls=RequiredIf,
-    options=["listener_auth"],
+    options=["listener_auth", "listener_config"],
 )
 @click.option(
     "--delete-config",
@@ -135,6 +142,7 @@ def clusters(
     delete_config,
     add_listener,
     listener_auth,
+    listener_config,
     delete_listener,
     authorization_type,
     super_user,
@@ -162,6 +170,7 @@ def clusters(
             delete_config,
             add_listener,
             listener_auth,
+            listener_config,
             delete_listener,
             authorization_type,
             super_user,
@@ -263,6 +272,7 @@ def alter(
     delete_config,
     add_listener,
     listener_auth,
+    listener_config,
     delete_listener,
     authorization_type,
     super_user,
@@ -295,7 +305,9 @@ def alter(
                     delete_config, cluster_dict["spec"]["kafka"]["config"]
                 )
 
-        _add_listeners_if_provided(add_listener, cluster_dict, listener_auth)
+        _add_listeners_if_provided(
+            add_listener, cluster_dict, listener_auth, listener_config
+        )
         _delete_listeners_if_provided(delete_listener, cluster_dict)
         _set_authorization_if_provided(
             authorization_type, super_user, authorizer_class, cluster_dict
@@ -377,13 +389,21 @@ def _add_config_if_provided(config, cluster_dict):
         add_kv_config_to_resource(config, cluster_dict["spec"]["kafka"]["config"])
 
 
-def _add_listeners_if_provided(add_listener, cluster_dict, listener_auth=None):
+def _add_listeners_if_provided(
+    add_listener, cluster_dict, listener_auth=None, listener_config=()
+):
     if len(add_listener) > 0:
         listeners = cluster_dict["spec"]["kafka"].setdefault("listeners", [])
         for listener_str in add_listener:
             new_listener = parse_kv_string(listener_str)
             if listener_auth:
                 new_listener["authentication"] = parse_kv_string(listener_auth)
+                if len(listener_config) > 0:
+                    new_listener["authentication"]["listenerConfig"] = {}
+                    add_kv_config_to_resource(
+                        listener_config,
+                        new_listener["authentication"]["listenerConfig"],
+                    )
             for existing in listeners:
                 if existing["name"] == new_listener["name"]:
                     existing.update(new_listener)

--- a/kfk/commands/configs.py
+++ b/kfk/commands/configs.py
@@ -131,6 +131,7 @@ def configs(
                 (),
                 None,
                 (),
+                (),
                 None,
                 (),
                 None,

--- a/tests/files/yaml/kafka-ephemeral_with_custom_auth_listener_config.yaml
+++ b/tests/files/yaml/kafka-ephemeral_with_custom_auth_listener_config.yaml
@@ -1,0 +1,36 @@
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+    - name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - name: tls
+      port: 9093
+      tls: true
+      type: internal
+    - authentication:
+        listenerConfig:
+          oauthClientId: kafka-broker
+          oauthValidIssuerUri: https://keycloak:8443/realms/kafka
+        sasl: true
+        type: custom
+      name: oauth
+      port: 9094
+      tls: true
+      type: internal
+    metadataVersion: 4.2-IV1
+    version: 4.2.0

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -956,7 +956,7 @@ class TestKfkClusters(TestCase):
     @mock.patch("kfk.commands.clusters.create_temp_file")
     @mock.patch("kfk.commons.get_resource_yaml")
     @mock.patch("kfk.commands.clusters.replace_using_yaml")
-    def test_alter_cluster_with_listener_config(
+    def test_alter_cluster_with_listener_auth_config(
         self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
     ):
         with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
@@ -971,9 +971,9 @@ class TestKfkClusters(TestCase):
                     "name=oauth,port=9094,type=internal,tls=true",
                     "--listener-auth",
                     "type=custom,sasl=true",
-                    "--listener-config",
+                    "--listener-auth-config",
                     "oauthClientId=kafka-broker",
-                    "--listener-config",
+                    "--listener-auth-config",
                     "oauthValidIssuerUri=https://keycloak:8443/realms/kafka",
                     "--cluster",
                     self.cluster,
@@ -993,7 +993,7 @@ class TestKfkClusters(TestCase):
 
         mock_replace_using_yaml.assert_called_once()
 
-    def test_listener_config_without_listener_auth_fails(self):
+    def test_listener_auth_config_without_listener_auth_fails(self):
         result = self.runner.invoke(
             kfk,
             [
@@ -1001,7 +1001,7 @@ class TestKfkClusters(TestCase):
                 "--alter",
                 "--add-listener",
                 "name=oauth,port=9094,type=internal,tls=true",
-                "--listener-config",
+                "--listener-auth-config",
                 "oauthClientId=kafka-broker",
                 "--cluster",
                 self.cluster,

--- a/tests/test_clusters_command.py
+++ b/tests/test_clusters_command.py
@@ -952,3 +952,62 @@ class TestKfkClusters(TestCase):
         )
         assert result.exit_code != 0
         assert "Missing option '--add-listener'" in result.output
+
+    @mock.patch("kfk.commands.clusters.create_temp_file")
+    @mock.patch("kfk.commons.get_resource_yaml")
+    @mock.patch("kfk.commands.clusters.replace_using_yaml")
+    def test_alter_cluster_with_listener_config(
+        self, mock_replace_using_yaml, mock_get_resource_yaml, mock_create_temp_file
+    ):
+        with open("tests/files/yaml/kafka-ephemeral.yaml") as file:
+            kafka_yaml = file.read()
+            mock_get_resource_yaml.return_value = kafka_yaml
+            result = self.runner.invoke(
+                kfk,
+                [
+                    "clusters",
+                    "--alter",
+                    "--add-listener",
+                    "name=oauth,port=9094,type=internal,tls=true",
+                    "--listener-auth",
+                    "type=custom,sasl=true",
+                    "--listener-config",
+                    "oauthClientId=kafka-broker",
+                    "--listener-config",
+                    "oauthValidIssuerUri=https://keycloak:8443/realms/kafka",
+                    "--cluster",
+                    self.cluster,
+                    "-n",
+                    self.namespace,
+                ],
+            )
+            assert result.exit_code == 0
+
+            with open(
+                "tests/files/yaml/"
+                "kafka-ephemeral_with_custom_auth_listener_config.yaml"
+            ) as file:
+                expected_kafka_yaml = file.read()
+                result_kafka_yaml = mock_create_temp_file.call_args[0][0]
+                assert expected_kafka_yaml == result_kafka_yaml
+
+        mock_replace_using_yaml.assert_called_once()
+
+    def test_listener_config_without_listener_auth_fails(self):
+        result = self.runner.invoke(
+            kfk,
+            [
+                "clusters",
+                "--alter",
+                "--add-listener",
+                "name=oauth,port=9094,type=internal,tls=true",
+                "--listener-config",
+                "oauthClientId=kafka-broker",
+                "--cluster",
+                self.cluster,
+                "-n",
+                self.namespace,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Missing option '--listener-auth'" in result.output


### PR DESCRIPTION
## Summary
- Add `--listener-config` flag (repeatable) to pass `listenerConfig` entries for custom listener authentication
- Sets `spec.kafka.listeners[].authentication.listenerConfig` in the Kafka CRD
- Uses `RequiredIf` to enforce `--listener-auth` is present when `--listener-config` is used
- `--add-listener` is also required when `--listener-config` is used

### Usage
```bash
kfk clusters --alter --cluster my-cluster -n kafka \
  --add-listener name=oauth,port=9094,type=internal,tls=true \
  --listener-auth type=custom,sasl=true \
  --listener-config oauthClientId=kafka-broker \
  --listener-config oauthValidIssuerUri=https://keycloak:8443/realms/kafka
```

## Test plan
- [x] `test_alter_cluster_with_listener_config`
- [x] `test_listener_config_without_listener_auth_fails`
- [x] All 148 tests pass
- [x] pre-commit clean

Closes #143